### PR TITLE
Creation of new servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ The goals of this project are as follows:
 ```bash
 go get -u github.com/silenceper/gowatch
 ```
-2. Until this tool can bootstrap new Minecraft instances on it's own, manually download `server.jar` from Minecraft's site (see below), and copy this into the path `testserver/server.jar`.
-3. Run tests (or use `make test`).
-4. Run `make` which will start the server. Load http://localhost:8080
+2. Run tests (or use `make test`).
+3. Run `make` which will start the server. Load http://localhost:8080
 
 ## Dependencies
 

--- a/client.go
+++ b/client.go
@@ -2,7 +2,7 @@ package pickaxx
 
 import (
 	"encoding/json"
-	"io"
+
 	"sync"
 	"time"
 
@@ -31,8 +31,6 @@ func (wc *websocketClient) Write(data []byte) error {
 
 	return err
 }
-
-var _ io.Writer = &ClientManager{}
 
 // ClientManager is a collection of clients
 type ClientManager struct {
@@ -88,19 +86,11 @@ func (c *ClientManager) AddClient(conn *websocket.Conn) {
 	}()
 }
 
-// Write will send data down a channel to be sent to clients. This
-// operation must write to a channel, as writes to an underlying
-// websocket can not happen concurrently.
-func (c *ClientManager) Write(data []byte) (int, error) {
+func (c *ClientManager) Write(data Data) {
+	bo, _ := json.Marshal(data)
 	holder := map[string]interface{}{}
-
-	// Send well-formed JSON as-is; wrap anything else as 'output'
-	if err := json.Unmarshal(data, &holder); err != nil {
-		holder = map[string]interface{}{"output": string(data)}
-	}
-
+	json.Unmarshal(bo, &holder)
 	c.output <- holder
-	return len(data), nil
 }
 
 func (c *ClientManager) broadcast(data map[string]interface{}) error {

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,7 @@
 package pickaxx
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/apex/log"
@@ -53,7 +54,7 @@ func TestClientManager(t *testing.T) {
 				defer m.Close()
 
 				m.AddClient(<-server.ConnectedSockets)
-				m.Write([]byte("hi there"))
+				m.Write(dummyEvent{"output", "hi there"})
 
 				assert.NoError(t, client.WaitReceive(websocket.TextMessage, `{"output":"hi there"}`))
 			},
@@ -65,7 +66,7 @@ func TestClientManager(t *testing.T) {
 				defer m.Close()
 
 				m.AddClient(<-server.ConnectedSockets)
-				m.Write([]byte(`{"status":"Running"}`))
+				m.Write(dummyEvent{"status", "Running"})
 
 				assert.NoError(t, client.WaitReceive(websocket.TextMessage, `{"status":"Running"}`))
 			},
@@ -84,4 +85,12 @@ func TestClientManager(t *testing.T) {
 			tc.checkFunc(t, &client)
 		})
 	}
+}
+
+type dummyEvent struct {
+	key, value string
+}
+
+func (e dummyEvent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]string{e.key: e.value})
 }

--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -87,7 +87,7 @@ func (h *ProcessHandler) startServer(c *gin.Context) {
 		return
 	}
 
-	server := minecraft.New(minecraft.DefaultPort)
+	server := minecraft.New(dataDir, minecraft.DefaultPort)
 	reporter := &loggingReporter{writer: h.clientWriter}
 
 	// start the server

--- a/cmd/httpserver.go
+++ b/cmd/httpserver.go
@@ -16,6 +16,10 @@ var (
 )
 
 func newRouter() *gin.Engine {
+	if version != "" {
+		gin.SetMode(gin.ReleaseMode)
+	}
+
 	e := gin.New()
 	e.Use(gin.Logger(), gin.Recovery())
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,14 +3,12 @@ package main
 import (
 	"flag"
 	"fmt"
-	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/cli"
-	"github.com/gin-gonic/gin"
 	"github.com/ivan3bx/pickaxx"
 )
 
@@ -43,13 +41,16 @@ func main() {
 	clientManager := pickaxx.ClientManager{}
 	ph := NewProcessHandler(&clientManager)
 
-	e.GET("/", func(c *gin.Context) { c.Redirect(http.StatusFound, "/server/_default") })
-	e.GET("/server/:key", ph.indexList)
-	e.POST("/server", ph.createNew)
-	e.PUT("/server", ph.commitNew)
-	e.DELETE("/server", ph.cancelNew)
-	e.POST("/server/:key/start", ph.startServer)
-	e.POST("/server/:key/stop", ph.stopServer)
+	// CRUD operations
+	e.GET("/", ph.index)
+	e.GET("/server/:key", ph.show)
+	e.POST("/server", ph.create)
+	e.DELETE("/server", ph.delete)
+	e.PUT("/server", ph.commit)
+
+	// State management
+	e.POST("/server/:key/start", ph.start)
+	e.POST("/server/:key/stop", ph.stop)
 	e.POST("/server/:key/send", ph.sendCommand)
 
 	// routes: client handling

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -40,20 +40,20 @@ func main() {
 	e := newRouter()
 
 	// routes: process handling
-	ph := ProcessHandler{
-		active:       make(map[string]*managedServer),
-		clientWriter: &pickaxx.ClientManager{},
-	}
+	clientManager := pickaxx.ClientManager{}
+	ph := NewProcessHandler(&clientManager)
 
 	e.GET("/", func(c *gin.Context) { c.Redirect(http.StatusFound, "/server/_default") })
-	e.GET("/server/:key", ph.rootHandler)
+	e.GET("/server/:key", ph.indexList)
 	e.POST("/server", ph.createNew)
+	e.PUT("/server", ph.commitNew)
+	e.DELETE("/server", ph.cancelNew)
 	e.POST("/server/:key/start", ph.startServer)
 	e.POST("/server/:key/stop", ph.stopServer)
 	e.POST("/server/:key/send", ph.sendCommand)
 
 	// routes: client handling
-	e.GET("/ws", webSocketHandler(ph.clientWriter.AddClient))
+	e.GET("/ws", webSocketHandler(clientManager.AddClient))
 
 	// Start the web server
 	srv := startWebServer(e)

--- a/cmd/reporter.go
+++ b/cmd/reporter.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/apex/log"
+	"github.com/ivan3bx/pickaxx"
+)
+
+type loggingReporter struct {
+	logFile *os.File
+	writer  pickaxx.Writer
+}
+
+func (r *loggingReporter) Report(ch <-chan pickaxx.Data) {
+	file, err := ioutil.TempFile(os.TempDir(), "pickaxx_log")
+
+	if err != nil {
+		log.WithError(err).Error("failed to create temp file")
+	}
+
+	r.logFile = file
+	defer func() {
+		r.logFile.Close()
+		log.Debug("reporter closed")
+	}()
+
+	for data := range ch {
+		r.writeConsoleOutput(data)
+		r.writer.Write(data)
+	}
+}
+
+func (r *loggingReporter) writeConsoleOutput(data pickaxx.Data) {
+	if consoleData, ok := data.(pickaxx.ConsoleData); ok {
+		io.WriteString(r.logFile, consoleData.String())
+		r.logFile.Write([]byte{'\n'})
+	}
+}
+
+func (r *loggingReporter) ConsoleOutput() []string {
+	content, _ := ioutil.ReadFile(r.logFile.Name())
+	return strings.Split(string(content), "\n")
+}

--- a/gowatch.yml
+++ b/gowatch.yml
@@ -4,6 +4,9 @@ build_pkg: ./cmd
 # path to build
 output: dist/pickaxx_dev
 
+cmd_args:
+    - -d=./dist/testdata
+
 # exclude changes in these paths from triggering build
 excluded_paths:
     - testserver

--- a/minecraft/manager.go
+++ b/minecraft/manager.go
@@ -26,9 +26,6 @@ const (
 
 	// DefaultPort is the default minecraft server port
 	DefaultPort = 25565
-
-	// DefaultWorkingDir is the default working directory
-	DefaultWorkingDir = "testserver"
 )
 
 // DefaultCommand is the name of the executable.
@@ -38,9 +35,10 @@ var DefaultCommand = []string{"java", MaxMem, MinMem, "-jar", JarFile, "nogui"}
 var ErrNoProcess = errors.New("no process running")
 
 // New creates a new process manager for an instance of Minecraft server.
-func New(port int) pickaxx.ProcessManager {
+func New(dataDir string, port int) pickaxx.ProcessManager {
 	return &serverManager{
-		Port: port,
+		WorkingDir: dataDir,
+		Port:       port,
 	}
 }
 
@@ -82,7 +80,7 @@ func (m *serverManager) Start() (<-chan pickaxx.Data, error) {
 	}
 
 	if m.WorkingDir == "" {
-		m.WorkingDir = DefaultWorkingDir
+		return nil, fmt.Errorf("no working directory configured")
 	}
 
 	if _, err := os.Stat(m.WorkingDir); err != nil {

--- a/minecraft/manager_test.go
+++ b/minecraft/manager_test.go
@@ -84,32 +84,19 @@ func TestNewServerManager(t *testing.T) {
 				}()
 
 				// Start the server
-				w := dummyMonitor{isReady: make(chan bool)}
-				err := m.Start(&w)
+				activity, err := m.Start()
 
 				if !assert.NoError(t, err) {
 					return
 				}
 
 				<-isRunning
-				<-w.isReady
 
 				// Run our test
-				tc.checkFunc(t, w.activityCh)
+				tc.checkFunc(t, activity)
 			})
 		}
 	})
-}
-
-type dummyMonitor struct {
-	isReady    chan bool // signals when channel can retrieve data
-	activityCh <-chan pickaxx.Data
-}
-
-func (c *dummyMonitor) Accept(ch <-chan pickaxx.Data) error {
-	c.activityCh = ch // set the activity channel
-	c.isReady <- true // signal that monitor is wired up
-	return nil
 }
 
 func assertAsync(t *testing.T, testFunc func() bool, msgs ...string) {

--- a/minecraft/manager_test.go
+++ b/minecraft/manager_test.go
@@ -2,6 +2,7 @@ package minecraft
 
 import (
 	"encoding/json"
+	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -12,12 +13,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var dataDir string
+
 func init() {
+	dataDir, _ = ioutil.TempDir(os.TempDir(), "pickaxx_minecraft")
+	log.WithField("path", dataDir).Info("test directory")
+
 	log.SetLevel(log.ErrorLevel)
 }
 func TestNewServerManager(t *testing.T) {
 	t.Run("initialized state", func(t *testing.T) {
-		m := New(DefaultPort)
+		m := New(dataDir, DefaultPort)
 
 		assert.False(t, m.Running())
 		assert.Error(t, m.Stop(), "expected error on newly initialized server")

--- a/minecraft/manager_test.go
+++ b/minecraft/manager_test.go
@@ -84,19 +84,32 @@ func TestNewServerManager(t *testing.T) {
 				}()
 
 				// Start the server
-				activity, err := m.Start()
+				w := dummyMonitor{isReady: make(chan bool)}
+				err := m.Start(&w)
 
 				if !assert.NoError(t, err) {
 					return
 				}
 
 				<-isRunning
+				<-w.isReady
 
 				// Run our test
-				tc.checkFunc(t, activity)
+				tc.checkFunc(t, w.activityCh)
 			})
 		}
 	})
+}
+
+type dummyMonitor struct {
+	isReady    chan bool // signals when channel can retrieve data
+	activityCh <-chan pickaxx.Data
+}
+
+func (c *dummyMonitor) Accept(ch <-chan pickaxx.Data) error {
+	c.activityCh = ch // set the activity channel
+	c.isReady <- true // signal that monitor is wired up
+	return nil
 }
 
 func assertAsync(t *testing.T, testFunc func() bool, msgs ...string) {

--- a/minecraft/process_io.go
+++ b/minecraft/process_io.go
@@ -2,6 +2,7 @@ package minecraft
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os/exec"
@@ -24,8 +25,8 @@ func (d consoleOutput) String() string { return d.Text }
 
 // MarshalJSON converts this output to valid JSON.
 func (d consoleOutput) MarshalJSON() ([]byte, error) {
-	jsonString := fmt.Sprintf(`{"output":"%s"}`, d.Text)
-	return []byte(jsonString), nil
+	holder := map[string]string{"output": d.String()}
+	return json.Marshal(&holder)
 }
 
 // stateChangeEvent represents a state transition event.

--- a/minecraft/process_io.go
+++ b/minecraft/process_io.go
@@ -12,19 +12,19 @@ import (
 )
 
 var (
-	_ pickaxx.Data = &consoleOutput{}
+	_ pickaxx.Data = &consoleEvent{}
 	_ pickaxx.Data = &stateChangeEvent{}
 )
 
-// consoleOutput represents console output (free-form text data).
-type consoleOutput struct {
+// consoleEvent represents console output (free-form text data).
+type consoleEvent struct {
 	Text string
 }
 
-func (d consoleOutput) String() string { return d.Text }
+func (d consoleEvent) String() string { return d.Text }
 
 // MarshalJSON converts this output to valid JSON.
-func (d consoleOutput) MarshalJSON() ([]byte, error) {
+func (d consoleEvent) MarshalJSON() ([]byte, error) {
 	holder := map[string]string{"output": d.String()}
 	return json.Marshal(&holder)
 }
@@ -44,7 +44,7 @@ func (d stateChangeEvent) MarshalJSON() ([]byte, error) {
 func pipeOutput(r io.Reader, out chan<- pickaxx.Data) {
 	s := bufio.NewScanner(r)
 	for s.Scan() {
-		out <- consoleOutput{s.Text()}
+		out <- consoleEvent{s.Text()}
 	}
 
 	if err := s.Err(); err != nil {

--- a/minecraft/process_io_test.go
+++ b/minecraft/process_io_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestConsoleOutput(t *testing.T) {
-	d := consoleOutput{"sample text"}
+	d := consoleEvent{"sample text"}
 
 	bo, _ := json.Marshal(&d)
 

--- a/minecraft/process_start.go
+++ b/minecraft/process_start.go
@@ -2,79 +2,11 @@ package minecraft
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"io"
-	"io/ioutil"
 
-	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/apex/log"
-	"github.com/ivan3bx/pickaxx"
 )
-
-var _ pickaxx.Monitor = &LogfileMonitor{}
-
-// LogfileMonitor monitors console output and sends data to a log file.
-type LogfileMonitor struct {
-	logFile *os.File
-}
-
-// Accept takes a channel and starts writing ConsoleData entries to a log file.
-func (m *LogfileMonitor) Accept(ch <-chan pickaxx.Data) error {
-	log := log.WithField("action", "LogfileMonitor.Accept()")
-
-	file, err := ioutil.TempFile(os.TempDir(), "pickaxx_log")
-
-	if err != nil {
-		log.WithError(err).Error("failed to create temp file")
-		return nil
-	}
-
-	m.logFile = file
-
-	for data := range ch {
-		if val, ok := data.(pickaxx.ConsoleData); ok {
-			line := fmt.Sprintf("%s\n", val.String())
-			io.WriteString(file, line)
-		}
-	}
-
-	log.Debug("channel closed")
-	return nil
-}
-
-// History returns recent entries equal to the number of lines in the param.
-// If length=-1, all available data is returned.
-func (m *LogfileMonitor) History(length int) []string {
-	content, _ := ioutil.ReadFile(m.logFile.Name())
-	lines := strings.Split(string(content), "\n")
-
-	if length == -1 || length > len(lines) {
-		return lines
-	}
-
-	return lines[:length]
-}
-
-// PassThruMonitor monitors activity and serializes it as JSON through a provided writer.
-type PassThruMonitor struct {
-	Writer io.Writer
-}
-
-// Accept takes a channel and starts writing ConsoleData entries to a log file.
-func (m *PassThruMonitor) Accept(ch <-chan pickaxx.Data) error {
-	log := log.WithField("action", "PassThruMonitor.Accept()")
-	enc := json.NewEncoder(m.Writer)
-
-	for data := range ch {
-		enc.Encode(data)
-	}
-	log.Debug("channel closed")
-	return nil
-}
 
 func startServer(ctx context.Context, m *serverManager) (*exec.Cmd, error) {
 	ctx, cancel := context.WithCancel(ctx)

--- a/minecraft/process_start.go
+++ b/minecraft/process_start.go
@@ -2,10 +2,83 @@ package minecraft
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/apex/log"
+	"github.com/ivan3bx/pickaxx"
 )
+
+var _ pickaxx.Logger = &logFileTracker{}
+
+type logFileTracker struct {
+	consoleLog   *os.File
+	clientWriter io.Writer
+}
+
+// NewTracker returns a new instance of a tracker that can
+// write data out to the provided writers.
+func NewTracker(w ...io.Writer) pickaxx.Logger {
+	file, err := ioutil.TempFile(os.TempDir(), "pickaxx_log")
+
+	if err != nil {
+		log.WithError(err).Error("failed to create temp file")
+		return nil
+	}
+
+	return &logFileTracker{
+		consoleLog:   file,
+		clientWriter: io.MultiWriter(w...),
+	}
+}
+
+func (t *logFileTracker) Write(p []byte) (n int, err error) {
+	line := fmt.Sprintf("%s\n", string(p))
+	return io.WriteString(t.consoleLog, line)
+}
+
+// Track will begin tracking activity from the given channel. This method
+// blocks the caller, and will return errors for any unexpected exit, or
+// 'nil' when the underlying channel is closed.
+func (t *logFileTracker) Track(ch <-chan pickaxx.Data) error {
+	log := log.WithField("action", "logFileTracker")
+	enc := json.NewEncoder(t.clientWriter)
+	// w := &newlineWriter{t.consoleLog}
+
+	for dataItem := range ch {
+
+		if err := enc.Encode(dataItem); err != nil {
+			log.WithError(err).Errorf("encoding failure: %v", dataItem)
+			return err
+		}
+		if val, ok := dataItem.(pickaxx.ConsoleData); ok {
+			t.Write([]byte(val.String()))
+			// // console output gets written to our writer
+			// io.WriteString(w, val.String())
+		}
+	}
+
+	log.Info("stopped")
+	return nil
+}
+
+// History returns recent entries equal to the number of lines,
+// or -1 if all available data should be returned.
+func (t *logFileTracker) History(length int) []string {
+	content, _ := ioutil.ReadFile(t.consoleLog.Name())
+	lines := strings.Split(string(content), "\n")
+
+	if length == -1 || length > len(lines) {
+		return lines
+	}
+
+	return lines[:length]
+}
 
 func startServer(ctx context.Context, m *serverManager) (*exec.Cmd, error) {
 	ctx, cancel := context.WithCancel(ctx)

--- a/process_manager.go
+++ b/process_manager.go
@@ -22,7 +22,7 @@ type ProcessManager interface {
 
 	// Start will execute an underlying process. Monitors may be
 	// provided and will receive a stream of activity data.
-	Start(...Monitor) error
+	Start() (<-chan Data, error)
 
 	// Stop will halt the process and release any resources.
 	Stop() error
@@ -34,13 +34,12 @@ type ProcessManager interface {
 	Submit(command string) error
 }
 
-// Monitor tracks activity for a stream of Data.
-type Monitor interface {
-	Accept(<-chan Data) error
+// Reporter reads from a Data channel and reports on it.
+type Reporter interface {
+	Report(<-chan Data)
 }
 
-// ConsoleMonitor tracks activity and returns recent history.
-type ConsoleMonitor interface {
-	Monitor
-	History(length int) []string
+// Writer can write out Data.
+type Writer interface {
+	Write(Data)
 }

--- a/process_manager.go
+++ b/process_manager.go
@@ -3,7 +3,6 @@ package pickaxx
 import (
 	"encoding/json"
 	"errors"
-	"io"
 )
 
 // ErrProcessExists exists when a new server process can not be started.
@@ -21,8 +20,9 @@ type ConsoleData interface {
 // ProcessManager can manage and interact with a process.
 type ProcessManager interface {
 
-	// Start will connect & initiate the underlying process.
-	Start() (<-chan Data, error)
+	// Start will execute an underlying process. Monitors may be
+	// provided and will receive a stream of activity data.
+	Start(...Monitor) error
 
 	// Stop will halt the process and release any resources.
 	Stop() error
@@ -34,16 +34,13 @@ type ProcessManager interface {
 	Submit(command string) error
 }
 
-// Logger emits activity for a stream of Data.
-type Logger interface {
-	io.Writer
+// Monitor tracks activity for a stream of Data.
+type Monitor interface {
+	Accept(<-chan Data) error
+}
 
-	// Track will begin tracking activity from the given channel. This method
-	// blocks until the provided context is canceled, any unexpected error, or
-	// if the underlying channel is closed.
-	Track(<-chan Data) error
-
-	// History returns recent entries equal to the number of lines,
-	// or -1 if all available data should be returned.
-	History(lines int) []string
+// ConsoleMonitor tracks activity and returns recent history.
+type ConsoleMonitor interface {
+	Monitor
+	History(length int) []string
 }

--- a/process_manager.go
+++ b/process_manager.go
@@ -3,6 +3,7 @@ package pickaxx
 import (
 	"encoding/json"
 	"errors"
+	"io"
 )
 
 // ErrProcessExists exists when a new server process can not be started.
@@ -31,4 +32,18 @@ type ProcessManager interface {
 
 	// Submit will send a command to the underlying process.
 	Submit(command string) error
+}
+
+// Logger emits activity for a stream of Data.
+type Logger interface {
+	io.Writer
+
+	// Track will begin tracking activity from the given channel. This method
+	// blocks until the provided context is canceled, any unexpected error, or
+	// if the underlying channel is closed.
+	Track(<-chan Data) error
+
+	// History returns recent entries equal to the number of lines,
+	// or -1 if all available data should be returned.
+	History(lines int) []string
 }

--- a/public/index.js
+++ b/public/index.js
@@ -21,7 +21,7 @@ function sendCommand(event) {
     return;
   }
 
-  const xhr = ajaxRequest('POST', event.currentTarget.action);
+  const xhr = ajaxRequest('POST', '/server/_default/send');
 
   xhr.onload = () => {
     inputBox.value = '';
@@ -40,8 +40,8 @@ const app = {
 
     // setup initial state
     inputForm.addEventListener('submit', sendCommand);
-    startButton.addEventListener('click', () => { ajaxRequest('POST', '/start').send(); });
-    stopButton.addEventListener('click', () => { ajaxRequest('POST', '/stop').send(); });
+    startButton.addEventListener('click', () => { ajaxRequest('POST', '/server/_default/start').send(); });
+    stopButton.addEventListener('click', () => { ajaxRequest('POST', '/server/_default/stop').send(); });
 
     fileDrop.init();
 

--- a/public/messages.js
+++ b/public/messages.js
@@ -68,7 +68,7 @@ function init(startButton, stopButton) {
   // lazy-load ReconnectingWebSocket.js
   var script = document.createElement('script');
   script.onload = onScriptLoad(websocketURL);
-  script.src = "assets/reconnecting-websocket.min.js";
+  script.src = "/assets/reconnecting-websocket.min.js";
   document.head.appendChild(script);
 
   resetScroll();

--- a/public/style.css
+++ b/public/style.css
@@ -6,6 +6,11 @@ body > .container {
     font-family: 'Courier New', Courier, monospace;
 }
 
+.link-unstyled, .link-unstyled:link, .link-unstyled:hover {
+    color: inherit;
+    text-decoration: inherit;
+}
+
 .header {
     color: #333;
 }

--- a/templates/_button_actions.html
+++ b/templates/_button_actions.html
@@ -1,0 +1,6 @@
+{{ define "button_actions" -}}
+<input id="startButton" type="button" class="btn btn-primary" value="Start Server"
+       {{- if (eq .status "Running" ) }} disabled {{- end }}>
+<input id="stopButton" type="button" class="btn btn-danger" value="Stop Server"
+       {{- if (eq .status "Stopped" ) }} disabled {{- end }}>
+{{- end }}

--- a/templates/_new_server_modal.html
+++ b/templates/_new_server_modal.html
@@ -1,0 +1,29 @@
+{{ define "new_server_modal" -}}
+<div class="modal fade" id="new-server-modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Creating new server</h5>
+            </div>
+            <div class="modal-body">
+                <form>
+                    <div class="form-group">
+                        <div class="progress">
+                            <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar"
+                                 style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label for="server-name" class="col-form-label">Name this server:</label>
+                        <input type="text" class="form-control" id="server-name" placeholder="My Great Server">
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary">Save</button>
+            </div>
+        </div>
+    </div>
+</div>
+{{ end }}

--- a/templates/_sidebar.html
+++ b/templates/_sidebar.html
@@ -1,0 +1,13 @@
+{{ define "sidebar" -}}
+<div class="col-2 servers text-white">
+    <h4 class="text-center">Servers</h4>
+    <ul class="server-list">
+        <li class="pb-4 pt-2">
+            <a href="#"><span class="font-weight-bold">+ Add New</span></a>
+        </li>
+        {{ range $server := .servers }}
+        <li data-key="{{ $server.key }}" class="selected">{{ $server.name }} </li>
+        {{ end }}
+    </ul>
+</div>
+{{ end }}

--- a/templates/_sidebar.html
+++ b/templates/_sidebar.html
@@ -6,7 +6,9 @@
             <a href="#"><span class="font-weight-bold">+ Add New</span></a>
         </li>
         {{ range $server := .servers }}
-        <li data-key="{{ $server.Key }}" class="selected">{{ $server.Name }} </li>
+        <li data-key="{{ $server.Key }}" class="{{ if eq $server.Key $.selected }}selected{{ end }}">
+            <a class="link-unstyled" href="/server/{{ $server.Key }}">{{ $server.Name }}</a>
+        </li>
         {{ end }}
     </ul>
 </div>

--- a/templates/_sidebar.html
+++ b/templates/_sidebar.html
@@ -6,7 +6,7 @@
             <a href="#"><span class="font-weight-bold">+ Add New</span></a>
         </li>
         {{ range $server := .servers }}
-        <li data-key="{{ $server.key }}" class="selected">{{ $server.name }} </li>
+        <li data-key="{{ $server.Key }}" class="selected">{{ $server.Name }} </li>
         {{ end }}
     </ul>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,10 +9,7 @@
 <body>
     <header>
         <nav class="navbar navbar-dark fixed-top bg-dark">
-            <div class="navbar-brand"><a href="/server/_default" class="link-unstyled">/pickaxx/</a></div>
-            <div class="justify-content-end">
-                {{ template "button_actions" . }}
-            </div>
+            <div class="navbar-brand"><a href="/" class="link-unstyled">/pickaxx/</a></div>
         </nav>
     </header>
     <!-- new server modal -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
 <body>
     <header>
         <nav class="navbar navbar-dark fixed-top bg-dark">
-            <div class="navbar-brand">/pickaxx/</div>
+            <div class="navbar-brand"><a href="/server/_default" class="link-unstyled">/pickaxx/</a></div>
             <div class="justify-content-end">
                 {{ template "button_actions" . }}
             </div>
@@ -23,8 +23,9 @@
             <div class="col-10 messages">
                 <div class="drop-zone">
                     <div class="upload-icon"></div>
-                    <p>To start a new server, drag & drop a <a
-                            href="https://www.minecraft.net/en-us/download/server">server.jar</a>.</p>
+                    <p>To start a new server, drag & drop a
+                        <a href="https://www.minecraft.net/en-us/download/server">server.jar</a>.
+                    </p>
                 </div>
                 <ul class="message-list">
                     {{ range $line := .logLines }}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,9 +1,9 @@
 <html>
 
 <head>
-    <link rel="stylesheet" href="assets/bootstrap.min.css">
-    <link rel="stylesheet" href="assets/style.css">
-    <link rel="preload" href="assets/grassblock.png" as="image">
+    <link rel="stylesheet" href="/assets/bootstrap.min.css">
+    <link rel="stylesheet" href="/assets/style.css">
+    <link rel="preload" href="/assets/grassblock.png" as="image">
 </head>
 
 <body>
@@ -84,9 +84,9 @@
             </div>
         </div>
     </main>
-    <script src="assets/jquery-3.5.1.min.js"></script>
-    <script src="assets/bootstrap.min.js"></script>
-    <script type="module" src="assets/index.js"></script>
+    <script src="/assets/jquery-3.5.1.min.js"></script>
+    <script src="/assets/bootstrap.min.js"></script>
+    <script type="module" src="/assets/index.js"></script>
 </body>
 
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,55 +11,15 @@
         <nav class="navbar navbar-dark fixed-top bg-dark">
             <div class="navbar-brand">/pickaxx/</div>
             <div class="justify-content-end">
-                <input id="startButton" type="button" class="btn btn-primary" value="Start Server"
-                    {{ if (eq .status "Running" ) }} disabled {{ end }}>
-                <input id="stopButton" type="button" class="btn btn-danger" value="Stop Server"
-                    {{ if (eq .status "Stopped" ) }} disabled {{ end }}>
+                {{ template "button_actions" . }}
             </div>
         </nav>
     </header>
-
-    <div class="modal fade" id="new-server-modal" tabindex="-1" role="dialog">
-        <div class="modal-dialog modal-dialog-centered" role="document">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">Creating new server</h5>
-                </div>
-                <div class="modal-body">
-                    <form>
-                        <div class="form-group">
-                            <div class="progress">
-                                <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar"
-                                    style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label for="server-name" class="col-form-label">Name this server:</label>
-                            <input type="text" class="form-control" id="server-name" placeholder="My Great Server">
-                        </div>
-                    </form>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-                    <button type="button" class="btn btn-primary">Save</button>
-                </div>
-            </div>
-        </div>
-    </div>
-
+    <!-- new server modal -->
+    {{ template "new_server_modal" .}}
     <main id="main-content">
         <div class="row h-100 content-pane">
-
-            <div class="col-2 servers text-white">
-                <h4 class="text-center">Servers</h4>
-                <ul class="server-list">
-                    <li class="pb-4 pt-2">
-                        <a href="#"><span class="font-weight-bold">+ Add New</span></a>
-                    </li>
-                    <li class="selected">Server 1</li>
-                </ul>
-            </div>
-
+            {{ template "sidebar" . }}
             <div class="col-10 messages">
                 <div class="drop-zone">
                     <div class="upload-icon"></div>


### PR DESCRIPTION
Replacing the scaffolding and single 'testserver' directory with a directory that pickaxx will use to store all servers / server metadata.

A new server is first 'staged' by storing the uploaded jar in a temp directory.  A separate endpoint will 'commit' this change by applying a name, storing some metadata and allowing it to show up in the sidebar.

The format of the server data is simple. Each server is a subdirectory, where it's name is the 'key' that will be resolved when the admin site is displayed.

```
<<data-dir>>
├── server_1        <-- key (i.e. "http://localhost:8080/server/server_1"
│   ├── pickaxx.json
│   ├── server.jar
│   └── ... other minecraft files
├── server_2        <-- key (i.e. "http://localhost:8080/server/server_2"
│   ├── pickaxx.json
│   ├── server.jar
│   └── ... other minecraft files
└── My_Great_Server <-- key (i.e. "http://localhost:8080/server/My_Great_Server"
    ├── pickaxx.json
    ├── server.jar
    └── ... other minecraft files
```

The `pickaxx.json` file is created through the interface, but should be optional.  The format in this PR just holds a creation date and a friendly name based on the 'key'.  Eventually it should be customizable and able to be renamed through the admin page.
```json
{
  "name": "server #1",
  "createdAt": "2021-01-02T13:18:47.616008-06:00"
}
```

### Major Changes

   - completed form submission & redirect
   - backend handlers for 'cancel' and 'commit'
   - backend methods to sanitize submitted server name
   - refactored index.html (extracted partials)
   - extracted logging into separate interface
   - refactored processmanager to allow > 1 servers

### Misc Changes
   - added CLI flag for data directory & verbose logging
   - setting gin_mode on release
   - updated readme